### PR TITLE
Fix some warnings in React 0.14

### DIFF
--- a/lib/process-node-definitions.js
+++ b/lib/process-node-definitions.js
@@ -19,6 +19,13 @@ function createStyleJsonFromString(styleString) {
     return jsonStyles;
 }
 
+var rename = {
+    'class': 'className',
+    'cellspacing': 'cellSpacing',
+    'cellpadding': 'cellPadding',
+    'colspan': 'colSpan'
+};
+
 var ProcessNodeDefinitions = function(React) {
     function processDefaultNode(node, children) {
         if (node.type === 'text') {
@@ -37,11 +44,12 @@ var ProcessNodeDefinitions = function(React) {
                     case 'style':
                         elementProps.style = createStyleJsonFromString(node.attribs.style);
                         break;
-                    case 'class':
-                        elementProps.className = value;
-                        break;
                     default:
-                        elementProps[key] = value;
+                        if ( rename[key] ) {
+                            elementProps[rename[key]] = value;
+                        } else {
+                            elementProps[key] = value;
+                        }
                         break;
                 }
             });

--- a/lib/process-node-definitions.js
+++ b/lib/process-node-definitions.js
@@ -55,7 +55,11 @@ var ProcessNodeDefinitions = function(React) {
             });
         }
 
-        return React.createElement(node.name, elementProps, node.data, children);
+        if ( children.length === 0 ) {
+          return React.createElement(node.name, elementProps, node.data, children);
+        } else {
+          return React.createElement(node.name, elementProps, node.data);
+        }
     }
 
     return {

--- a/lib/process-node-definitions.js
+++ b/lib/process-node-definitions.js
@@ -55,11 +55,11 @@ var ProcessNodeDefinitions = function(React) {
             });
         }
 
-        if ( children.length === 0 ) {
+        // if ( children.length === 0 ) {
           return React.createElement(node.name, elementProps, node.data, children);
-        } else {
-          return React.createElement(node.name, elementProps, node.data);
-        }
+        // } else {
+        //   return React.createElement(node.name, elementProps, node.data);
+        // }
     }
 
     return {

--- a/package.json
+++ b/package.json
@@ -36,10 +36,10 @@
   },
   "dependencies": {
     "htmlparser2": "^3.8.3",
-    "lodash": "^3.9.3",
-    "react": "^0.13.3"
+    "lodash": "^3.9.3"
   },
   "devDependencies": {
+    "react": "^0.13.3",
     "blanket": "^1.1.7",
     "coveralls": "^2.11.2",
     "mocha": "^2.2.5",

--- a/test/html-to-react-tests.js
+++ b/test/html-to-react-tests.js
@@ -194,6 +194,56 @@ describe('Html2React with custom processing instructions', function() {
             var reactHtml = React.renderToStaticMarkup(reactComponent);
             assert.equal(reactHtml, htmlExpected);
         });
+
+        it('should not generate children when there are none', function () {
+            var htmlInput    = '<img src="foo.png"></img>';
+            var htmlExpected = '<img src="foo.png">';
+
+            var isValidNode = function() {
+                return true;
+            };
+
+            var processingInstructions = [{
+              shouldProcessNode: function(node) { return true; },
+              processNode: processNodeDefinitions.processDefaultNode
+            }];
+            var reactComponent = parser.parseWithInstructions(htmlInput, isValidNode, processingInstructions);
+            var reactHtml = React.renderToStaticMarkup(reactComponent);
+            assert.equal(reactHtml, htmlExpected);
+        });
+
+        it('should generate children when there are some', function () {
+            var htmlInput    = '<div>foo</div>';
+
+            var isValidNode = function() {
+                return true;
+            };
+
+            var processingInstructions = [{
+              shouldProcessNode: function(node) { return true; },
+              processNode: processNodeDefinitions.processDefaultNode
+            }];
+            var reactComponent = parser.parseWithInstructions(htmlInput, isValidNode, processingInstructions);
+            assert.notEqual(reactComponent._store.props.children.length, 0);
+        });
+
+        it('should generate correct casing for react attributes', function () {
+            var htmlInput    = '<div class="foo" cellspacing="1" cellpadding="1" colspan="1">ok</div>';
+            var htmlExpected = htmlInput;
+
+            var isValidNode = function() {
+                return true;
+            };
+
+            var processingInstructions = [{
+              shouldProcessNode: function(node) { return true; },
+              processNode: processNodeDefinitions.processDefaultNode
+            }];
+            var reactComponent = parser.parseWithInstructions(htmlInput, isValidNode, processingInstructions);
+            [ 'className', 'cellSpacing', 'cellPadding', 'colSpan' ].forEach(function (key) {
+              assert.notStrictEqual(reactComponent._store.props[key], undefined, 'react component does not have prop: ' + key);
+            });
+        });
     });
 });
 


### PR DESCRIPTION
I got warnings for a lot of table-specific attributes like `cellpadding` and `cellspacing` because React expects them like `cellPadding` and `cellSpacing`.

Also fixed an issue where React was complaining about `<img>` tags receiving children when it shouldn't (even if the input html was valid).
