### PR TITLE
Avoid creating children for br elements

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,10 @@
+root = true
+
+[*]
+indent_style = space
+end_of_line = lf
+insert_final_newline = true
+max_line_length = 100
+
+[*.js]
+indent_size = 4

--- a/lib/is-valid-node-definitions.js
+++ b/lib/is-valid-node-definitions.js
@@ -1,9 +1,8 @@
 'use strict';
-
 function alwaysValid() {
     return true;
 }
 
 module.exports = {
-    alwaysValid: alwaysValid
+    alwaysValid: alwaysValid,
 };

--- a/lib/parser.js
+++ b/lib/parser.js
@@ -23,8 +23,12 @@ var Html2React = function(React) {
                     processingInstruction) {
                 return processingInstruction.shouldProcessNode(node);
             });
-            children = _.compact(children); // Remove invalid nodes
-            return processingInstruction.processNode(node, children, index);
+            if (processingInstruction != null) {
+                children = _.compact(children); // Remove invalid nodes
+                return processingInstruction.processNode(node, children, index);
+            } else {
+                return false;
+            }
         }
         return false;
     };

--- a/lib/parser.js
+++ b/lib/parser.js
@@ -13,19 +13,18 @@ var Html2React = function(React) {
         return handler.dom;
     };
 
-    var traverseDom = function(node, isValidNode, processingInstructions) {
+    var traverseDom = function(node, isValidNode, processingInstructions, index) {
         if (isValidNode(node)) {
             var children = [];
-            _.each(node.children, function(child) {
-                children.push(traverseDom(child, isValidNode, processingInstructions));
+            _.forEach(node.children, function(child, index) {
+                children.push(traverseDom(child, isValidNode, processingInstructions, index));
             });
             _.compact(children); // Remove invalid nodes
-            for (var index = 0; index < processingInstructions.length; index++) {
-                var processingInstruction = processingInstructions[index];
+            _.forEach(processingInstructions, function (processingInstruction) {
                 if (processingInstruction.shouldProcessNode(node)) {
-                    return processingInstruction.processNode(node, children);
+                    return processingInstruction.processNode(node, children, index);
                 }
-            }
+            })
         }
         return false;
     };
@@ -38,7 +37,7 @@ var Html2React = function(React) {
             'The HTML provided contains ' + domTree.length + ' root elements. You can fix that by simply wrapping your HTML ' +
             'in a <div> element.');
         }
-        return traverseDom(domTree[0], isValidNode, processingInstructions);
+        return traverseDom(domTree[0], isValidNode, processingInstructions, 0);
     };
 
     var parse = function(html) {
@@ -55,4 +54,3 @@ var Html2React = function(React) {
 };
 
 module.exports = Html2React;
-

--- a/lib/parser.js
+++ b/lib/parser.js
@@ -17,10 +17,10 @@ var Html2React = function(React) {
             var children = [];
             var children = R.addIndex(R.map)(function (child, index) {
                 return traverseDom(child, isValidNode, processingInstructions, index);
-            }, node.children);
+            }, node.children || []);
             var processingInstruction = R.find(function (processingInstruction) {
                 return processingInstruction.shouldProcessNode(node);
-            }, processingInstructions);
+            }, processingInstructions || []);
             if (processingInstruction != null) {
                 children = R.filter(R.identity, children); // Remove invalid nodes
                 return processingInstruction.processNode(node, children, index);

--- a/lib/parser.js
+++ b/lib/parser.js
@@ -19,12 +19,12 @@ var Html2React = function(React) {
             _.forEach(node.children, function(child, index) {
                 children.push(traverseDom(child, isValidNode, processingInstructions, index));
             });
-            _.compact(children); // Remove invalid nodes
-            _.forEach(processingInstructions, function (processingInstruction) {
-                if (processingInstruction.shouldProcessNode(node)) {
-                    return processingInstruction.processNode(node, children, index);
-                }
-            })
+            var processingInstruction = _.find(processingInstructions, function (
+                    processingInstruction) {
+                return processingInstruction.shouldProcessNode(node);
+            });
+            children = _.compact(children); // Remove invalid nodes
+            return processingInstruction.processNode(node, children, index);
         }
         return false;
     };

--- a/lib/parser.js
+++ b/lib/parser.js
@@ -1,6 +1,5 @@
 'use strict';
-
-var _ = require('lodash');
+var R = require('ramda');
 var htmlParser = require('htmlparser2');
 var ProcessingInstructions = require('./processing-instructions');
 var IsValidNodeDefinitions = require('./is-valid-node-definitions');
@@ -16,15 +15,14 @@ var Html2React = function(React) {
     var traverseDom = function(node, isValidNode, processingInstructions, index) {
         if (isValidNode(node)) {
             var children = [];
-            _.forEach(node.children, function(child, index) {
-                children.push(traverseDom(child, isValidNode, processingInstructions, index));
-            });
-            var processingInstruction = _.find(processingInstructions, function (
-                    processingInstruction) {
+            var children = R.addIndex(R.map)(function (child, index) {
+                return traverseDom(child, isValidNode, processingInstructions, index);
+            }, node.children);
+            var processingInstruction = R.find(function (processingInstruction) {
                 return processingInstruction.shouldProcessNode(node);
-            });
+            }, processingInstructions);
             if (processingInstruction != null) {
-                children = _.compact(children); // Remove invalid nodes
+                children = R.filter(R.identity, children); // Remove invalid nodes
                 return processingInstruction.processNode(node, children, index);
             } else {
                 return false;
@@ -54,7 +52,7 @@ var Html2React = function(React) {
 
     return {
         parse: parse,
-        parseWithInstructions: parseWithInstructions
+        parseWithInstructions: parseWithInstructions,
     };
 };
 

--- a/lib/parser.js
+++ b/lib/parser.js
@@ -29,8 +29,9 @@ var Html2React = function(React) {
             } else {
                 return false;
             }
+        } else {
+            return false;
         }
-        return false;
     };
 
     var parseWithInstructions = function(html, isValidNode, processingInstructions) {

--- a/lib/process-node-definitions.js
+++ b/lib/process-node-definitions.js
@@ -20,7 +20,7 @@ function createStyleJsonFromString(styleString) {
 }
 
 var ProcessNodeDefinitions = function(React) {
-    function processDefaultNode(node, children) {
+    function processDefaultNode(node, children, index) {
         if (node.type === 'text') {
             return node.data;
         } else if (node.type === 'comment') {
@@ -29,7 +29,9 @@ var ProcessNodeDefinitions = function(React) {
             return false;
         }
 
-        var elementProps = {};
+        var elementProps = {
+            key: index,
+        };
         // Process attributes
         if (node.attribs) {
             _.each(node.attribs, function(value, key) {
@@ -47,6 +49,11 @@ var ProcessNodeDefinitions = function(React) {
             });
         }
 
+        if (node.name === 'br') {
+            // Avoid specifying children as otherwise React will add a bogus child array to the
+            // element, which causes warnings further down the chain
+            return React.createElement(node.name, elementProps);
+        }
         return React.createElement(node.name, elementProps, node.data, children);
     }
 
@@ -56,4 +63,3 @@ var ProcessNodeDefinitions = function(React) {
 };
 
 module.exports = ProcessNodeDefinitions;
-

--- a/lib/process-node-definitions.js
+++ b/lib/process-node-definitions.js
@@ -1,6 +1,7 @@
 'use strict';
 
 var _ = require('lodash');
+var ent = require('ent');
 
 function createStyleJsonFromString(styleString) {
     if (_.isNull(styleString) || _.isUndefined(styleString) || styleString === '') {
@@ -19,16 +20,10 @@ function createStyleJsonFromString(styleString) {
     return jsonStyles;
 }
 
-function htmlDecode(input) {
-  var e = document.createElement('div');
-  e.innerHTML = input;
-  return e.childNodes.length === 0 ? '' : e.childNodes[0].nodeValue;
-}
-
 var ProcessNodeDefinitions = function(React) {
     function processDefaultNode(node, children, index) {
         if (node.type === 'text') {
-            return htmlDecode(node.data);
+            return ent.decode(node.data);
         } else if (node.type === 'comment') {
             // FIXME: The following doesn't work as the generated HTML results in "&lt;!--  This is a comment  --&gt;"
             //return '<!-- ' + node.data + ' -->';

--- a/lib/process-node-definitions.js
+++ b/lib/process-node-definitions.js
@@ -1,17 +1,18 @@
 'use strict';
 
-var _ = require('lodash');
+var S = require('underscore.string.fp');
+var R = require('ramda');
 var ent = require('ent');
 
 function createStyleJsonFromString(styleString) {
-    if (_.isNull(styleString) || _.isUndefined(styleString) || styleString === '') {
+    if (S.isBlank(styleString)) {
         return {};
     }
     var styles = styleString.split(';');
     var singleStyle, key, value, jsonStyles = {};
     for (var i = 0; i < styles.length; i++) {
         singleStyle = styles[i].split(':');
-        key = _.camelCase(singleStyle[0]);
+        key = S.camelize(singleStyle[0]);
         value = singleStyle[1];
         if (key.length > 0 && value.length > 0) {
             jsonStyles[key] = value;
@@ -25,7 +26,8 @@ var ProcessNodeDefinitions = function(React) {
         if (node.type === 'text') {
             return ent.decode(node.data);
         } else if (node.type === 'comment') {
-            // FIXME: The following doesn't work as the generated HTML results in "&lt;!--  This is a comment  --&gt;"
+            // FIXME: The following doesn't work as the generated HTML results in
+            // "&lt;!--  This is a comment  --&gt;"
             //return '<!-- ' + node.data + ' -->';
             return false;
         }
@@ -35,7 +37,7 @@ var ProcessNodeDefinitions = function(React) {
         };
         // Process attributes
         if (node.attribs) {
-            _.each(node.attribs, function(value, key) {
+            R.forEach(function(value, key) {
                 switch (key || '') {
                     case 'style':
                         elementProps.style = createStyleJsonFromString(node.attribs.style);
@@ -47,7 +49,7 @@ var ProcessNodeDefinitions = function(React) {
                         elementProps[key] = value;
                         break;
                 }
-            });
+            }, node.attribs);
         }
 
         if (node.name === 'br') {
@@ -60,7 +62,7 @@ var ProcessNodeDefinitions = function(React) {
     }
 
     return {
-        processDefaultNode: processDefaultNode
+        processDefaultNode: processDefaultNode,
     };
 };
 

--- a/lib/process-node-definitions.js
+++ b/lib/process-node-definitions.js
@@ -19,10 +19,16 @@ function createStyleJsonFromString(styleString) {
     return jsonStyles;
 }
 
+function htmlDecode(input) {
+  var e = document.createElement('div');
+  e.innerHTML = input;
+  return e.childNodes.length === 0 ? '' : e.childNodes[0].nodeValue;
+}
+
 var ProcessNodeDefinitions = function(React) {
     function processDefaultNode(node, children, index) {
         if (node.type === 'text') {
-            return node.data;
+            return htmlDecode(node.data);
         } else if (node.type === 'comment') {
             // FIXME: The following doesn't work as the generated HTML results in "&lt;!--  This is a comment  --&gt;"
             //return '<!-- ' + node.data + ' -->';

--- a/lib/process-node-definitions.js
+++ b/lib/process-node-definitions.js
@@ -54,8 +54,9 @@ var ProcessNodeDefinitions = function(React) {
             // Avoid specifying children as otherwise React will add a bogus child array to the
             // element, which causes warnings further down the chain
             return React.createElement(node.name, elementProps);
+        } else {
+            return React.createElement(node.name, elementProps, node.data, children);
         }
-        return React.createElement(node.name, elementProps, node.data, children);
     }
 
     return {

--- a/lib/processing-instructions.js
+++ b/lib/processing-instructions.js
@@ -1,5 +1,4 @@
 'use strict';
-
 var ShouldProcessNodeDefinitions = require('./should-process-node-definitions');
 var ProcessNodeDefinitions = require('./process-node-definitions');
 
@@ -9,10 +8,9 @@ var ProcessingInstructions = function(React) {
     return {
         defaultProcessingInstructions: [{
             shouldProcessNode: ShouldProcessNodeDefinitions.shouldProcessEveryNode,
-            processNode: processNodeDefinitions.processDefaultNode
-        }]
+            processNode: processNodeDefinitions.processDefaultNode,
+        },],
     };
 };
 
 module.exports = ProcessingInstructions;
-

--- a/lib/should-process-node-definitions.js
+++ b/lib/should-process-node-definitions.js
@@ -1,9 +1,8 @@
 'use strict';
-
 function shouldProcessEveryNode(node) {
     return true;
 }
 
 module.exports = {
-    shouldProcessEveryNode: shouldProcessEveryNode
+    shouldProcessEveryNode: shouldProcessEveryNode,
 };

--- a/package.json
+++ b/package.json
@@ -37,8 +37,9 @@
   "dependencies": {
     "ent": "^2.2.0",
     "htmlparser2": "^3.8.3",
-    "lodash": "^3.9.3",
-    "react": "^0.13.3"
+    "react": "^0.13.3",
+    "ramda": "^0.19.1",
+    "underscore.string.fp": "^1.0.4"
   },
   "devDependencies": {
     "blanket": "^1.1.7",

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     }
   },
   "dependencies": {
+    "ent": "^2.2.0",
     "htmlparser2": "^3.8.3",
     "lodash": "^3.9.3",
     "react": "^0.13.3"

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
   "dependencies": {
     "ent": "^2.2.0",
     "htmlparser2": "^3.8.3",
-    "react": "^0.13.3",
+    "react": "^0.14.3",
     "ramda": "^0.19.1",
     "underscore.string.fp": "^1.0.4"
   },

--- a/test/html-to-react-tests.js
+++ b/test/html-to-react-tests.js
@@ -94,6 +94,13 @@ describe('Html2React', function() {
 
             assert.equal(reactHtml, htmlExpected);
         });
+
+        it('should not generate children for br tags', function() {
+            var htmlInput = '<br/>';
+
+            var reactComponent = parser.parse(htmlInput);
+            assert.strictEqual((reactComponent.props.children || []).length, 0);
+        });
     });
 
     describe('parse invalid HTML', function() {
@@ -196,4 +203,3 @@ describe('Html2React with custom processing instructions', function() {
         });
     });
 });
-


### PR DESCRIPTION
When generating React components for `br` elements and specifying children as per usual, React will warn later that void elements such as `br` should not have children.

This PR ensures that React components created from `br` elements are created without children and adds a test for it as well.

Additionally, I made sure to decode HTML entities of text nodes before handing them over to `React.createElement` as the latter will do its own encoding (and in effect double encode HTML entities), as well as adding a [.editorconfig](http://editorconfig.org/) file for ease of editing.
