### PR TITLE
Fix br warning

### DIFF
--- a/lib/process-node-definitions.js
+++ b/lib/process-node-definitions.js
@@ -51,6 +51,10 @@ var ProcessNodeDefinitions = function(React) {
             });
         }
 
+        children = _.filter(children, function(child) {
+            return child.type !== 'br';
+        });
+
         return React.createElement(node.name, elementProps, node.data, children);
     }
 


### PR DESCRIPTION
When adding html that has a `<br>` tag in it, react logs the following warning:

> Warning: br is a void element tag and must not have `children` or use `props.dangerouslySetInnerHTML`. Check the render method of...

I've made a change to the code that cycles through all the children and removes any `<br>` tags. I'm not sure if this is performant but it does solve the issue. I'd be grateful for any comments :)
