### PR TITLE
Replace ampersand with unicode character

### DIFF
--- a/lib/process-node-definitions.js
+++ b/lib/process-node-definitions.js
@@ -51,6 +51,14 @@ var ProcessNodeDefinitions = function(React) {
             });
         }
 
+        children = _.map(children, function(child) {
+            if (typeof child === 'string') {
+                return child.replace(/&amp;/g, '\u0026');
+            }
+
+            return child;
+        });
+
         return React.createElement(node.name, elementProps, node.data, children);
     }
 


### PR DESCRIPTION
When a special character such as `&amp;` appears in the html that is parsed, it's not displayed correctly. Here's an explanation:

https://facebook.github.io/react/docs/jsx-gotchas.html

I'm looping though all children and replacing all occurrences of ampersand with its unicode character.

I think it might be better to do an old-fashioned for loop that combines this PR and #13 - it's open to discussion :)
