### PR TITLE
Make sure tests fail on console warnings

### DIFF
--- a/test/html-to-react-tests.js
+++ b/test/html-to-react-tests.js
@@ -10,6 +10,12 @@ var ProcessNodeDefinitions = require('../index').ProcessNodeDefinitions;
 describe('Html2React', function() {
     var parser = new Parser(React);
 
+    before(function() {
+      console.error = function(message) {
+        throw new Error(message);
+      };
+    })
+
     describe('parse valid HTML', function() {
         it('should return a valid HTML string', function() {
             var htmlInput = '<p>Does this work?</p>';
@@ -124,76 +130,76 @@ describe('Html2React', function() {
             assert.equal(reactHtml, htmlExpected);
         });
     });
-});
 
-describe('Html2React with custom processing instructions', function() {
-    var parser = new Parser(React);
-    var processNodeDefinitions = new ProcessNodeDefinitions(React);
+    describe('with custom processing instructions', function() {
+        var parser = new Parser(React);
+        var processNodeDefinitions = new ProcessNodeDefinitions(React);
 
-    describe('parse valid HTML', function() {
-        it('should return nothing with only a single <p> element', function() {
-            var htmlInput = '<p>Does this work?</p>';
-            var isValidNode = function() {
-                return true;
-            };
-            var processingInstructions = [{
-                shouldProcessNode: function(node) {
-                    return node.name && node.name !== 'p';
-                },
-                processNode: processNodeDefinitions.processDefaultNode
-            }];
-            var reactComponent = parser.parseWithInstructions(htmlInput, isValidNode, processingInstructions);
-
-            // With only 1 <p> element, nothing is rendered
-            assert.equal(reactComponent, false);
-        });
-
-        it('should return a single <h1> element within a div of <h1> and <p> as siblings', function() {
-            var htmlInput = '<div><h1>Title</h1><p>Paragraph</p></div>';
-            var htmlExpected = '<div><h1>Title</h1></div>';
-
-            var isValidNode = function() {
-                return true;
-            };
-
-            var processingInstructions = [{
-                shouldProcessNode: function(node) {
-                    return node.type === 'text' || node.name !== 'p';
-                },
-                processNode: processNodeDefinitions.processDefaultNode
-            }];
-            var reactComponent = parser.parseWithInstructions(htmlInput, isValidNode, processingInstructions);
-            var reactHtml = ReactDOMServer.renderToStaticMarkup(reactComponent);
-            assert.equal(reactHtml, htmlExpected);
-        });
-
-        it('should return capitalized content for all <h1> elements', function() {
-            var htmlInput = '<div><h1>Title</h1><p>Paragraph</p><h1>Another title</h1></div>';
-            var htmlExpected = '<div><h1>TITLE</h1><p>Paragraph</p><h1>ANOTHER TITLE</h1></div>';
-
-            var isValidNode = function() {
-                return true;
-            };
-
-            var processingInstructions = [
-                {
-                    // Custom <h1> processing
+        describe('parse valid HTML', function() {
+            it('should return nothing with only a single <p> element', function() {
+                var htmlInput = '<p>Does this work?</p>';
+                var isValidNode = function() {
+                    return true;
+                };
+                var processingInstructions = [{
                     shouldProcessNode: function(node) {
-                        return node.parent && node.parent.name && node.parent.name === 'h1';
-                    },
-                    processNode: function(node, children) {
-                        return node.data.toUpperCase();
-                    }
-                }, {
-                    // Anything else
-                    shouldProcessNode: function(node) {
-                        return true;
+                        return node.name && node.name !== 'p';
                     },
                     processNode: processNodeDefinitions.processDefaultNode
                 }];
-            var reactComponent = parser.parseWithInstructions(htmlInput, isValidNode, processingInstructions);
-            var reactHtml = ReactDOMServer.renderToStaticMarkup(reactComponent);
-            assert.equal(reactHtml, htmlExpected);
+                var reactComponent = parser.parseWithInstructions(htmlInput, isValidNode, processingInstructions);
+
+                // With only 1 <p> element, nothing is rendered
+                assert.equal(reactComponent, false);
+            });
+
+            it('should return a single <h1> element within a div of <h1> and <p> as siblings', function() {
+                var htmlInput = '<div><h1>Title</h1><p>Paragraph</p></div>';
+                var htmlExpected = '<div><h1>Title</h1></div>';
+
+                var isValidNode = function() {
+                    return true;
+                };
+
+                var processingInstructions = [{
+                    shouldProcessNode: function(node) {
+                        return node.type === 'text' || node.name !== 'p';
+                    },
+                    processNode: processNodeDefinitions.processDefaultNode
+                }];
+                var reactComponent = parser.parseWithInstructions(htmlInput, isValidNode, processingInstructions);
+                var reactHtml = ReactDOMServer.renderToStaticMarkup(reactComponent);
+                assert.equal(reactHtml, htmlExpected);
+            });
+
+            it('should return capitalized content for all <h1> elements', function() {
+                var htmlInput = '<div><h1>Title</h1><p>Paragraph</p><h1>Another title</h1></div>';
+                var htmlExpected = '<div><h1>TITLE</h1><p>Paragraph</p><h1>ANOTHER TITLE</h1></div>';
+
+                var isValidNode = function() {
+                    return true;
+                };
+
+                var processingInstructions = [
+                    {
+                        // Custom <h1> processing
+                        shouldProcessNode: function(node) {
+                            return node.parent && node.parent.name && node.parent.name === 'h1';
+                        },
+                        processNode: function(node, children) {
+                            return node.data.toUpperCase();
+                        }
+                    }, {
+                        // Anything else
+                        shouldProcessNode: function(node) {
+                            return true;
+                        },
+                        processNode: processNodeDefinitions.processDefaultNode
+                    }];
+                var reactComponent = parser.parseWithInstructions(htmlInput, isValidNode, processingInstructions);
+                var reactHtml = ReactDOMServer.renderToStaticMarkup(reactComponent);
+                assert.equal(reactHtml, htmlExpected);
+            });
         });
     });
 });


### PR DESCRIPTION
Overrides the `console.error` function to throw an `Error` if it gets called. This ensures we capture any React warnings and deal with them appropriately.
