### PR TITLE
Deal with void element tags

### DIFF
--- a/lib/process-node-definitions.js
+++ b/lib/process-node-definitions.js
@@ -2,6 +2,12 @@
 
 var _ = require('lodash');
 
+// https://github.com/facebook/react/blob/0.14-stable/src/renderers/dom/shared/ReactDOMComponent.js#L457
+var voidElementTags = [
+    'area', 'base', 'br', 'col', 'embed', 'hr', 'img', 'input',
+    'keygen', 'link', 'meta', 'param', 'source', 'track', 'wbr'
+];
+
 function createStyleJsonFromString(styleString) {
     if (_.isNull(styleString) || _.isUndefined(styleString) || styleString === '') {
         return {};
@@ -51,7 +57,12 @@ var ProcessNodeDefinitions = function(React) {
             });
         }
 
-        return React.createElement(node.name, elementProps, node.data, children);
+        if (_.contains(voidElementTags, node.name)) {
+            return React.createElement(node.name, elementProps)
+        } else {
+            return React.createElement(node.name, elementProps, node.data, children);
+        }
+
     }
 
     return {
@@ -60,4 +71,3 @@ var ProcessNodeDefinitions = function(React) {
 };
 
 module.exports = ProcessNodeDefinitions;
-

--- a/test/html-to-react-tests.js
+++ b/test/html-to-react-tests.js
@@ -112,7 +112,14 @@ describe('Html2React', function() {
             assert.equal(reactHtml, htmlExpected);
         });
 
-        it('should parse src elements with all attributes but without warnings', function() {
+        it('should not generate children for br tags', function() {
+            var htmlInput = '<br/>';
+
+            var reactComponent = parser.parse(htmlInput);
+            assert.strictEqual((reactComponent.props.children || []).length, 0);
+         });
+
+        it('should parse void elements with all attributes and no warnings', function() {
             var htmlInput = '<p><img src="www.google.ca/logo.png"/></p>';
 
             var reactComponent = parser.parse(htmlInput);

--- a/test/html-to-react-tests.js
+++ b/test/html-to-react-tests.js
@@ -101,6 +101,25 @@ describe('Html2React', function() {
 
             assert.equal(reactHtml, htmlExpected);
         });
+
+        it('should parse br elements without warnings', function() {
+            var htmlInput = '<div><p>Line one<br>Line two<br/>Line three</p></div>';
+            var htmlExpected = '<div><p>Line one<br/>Line two<br/>Line three</p></div>';
+
+            var reactComponent = parser.parse(htmlInput);
+            var reactHtml = ReactDOMServer.renderToStaticMarkup(reactComponent);
+
+            assert.equal(reactHtml, htmlExpected);
+        });
+
+        it('should parse src elements with all attributes but without warnings', function() {
+            var htmlInput = '<p><img src="www.google.ca/logo.png"/></p>';
+
+            var reactComponent = parser.parse(htmlInput);
+            var reactHtml = ReactDOMServer.renderToStaticMarkup(reactComponent);
+
+            assert.equal(reactHtml, htmlInput);
+        });
     });
 
     describe('parse invalid HTML', function() {


### PR DESCRIPTION
This is similar to #13, but a bit more generic. It also fixes parts of #8.

Status: **Ready for review**
Reviewers: @lithin @aknuds1
## Changes
- Created a list of void element tags (same as React uses to generate the console warnings)
- Use the above list to determine when and when _not_ to create children of a component
- Added test cases to cover two void element tag scenarios
