### PR TITLE
Upgrade to lodash 4.3.0

### DIFF
--- a/lib/process-node-definitions.js
+++ b/lib/process-node-definitions.js
@@ -3,7 +3,7 @@
 var _ = require('lodash');
 
 function createStyleJsonFromString(styleString) {
-    if (_.isNull(styleString) || _.isUndefined(styleString) || styleString === '') {
+    if (_.isNil(styleString) || styleString === '') {
         return {};
     }
     var styles = styleString.split(';');
@@ -60,4 +60,3 @@ var ProcessNodeDefinitions = function(React) {
 };
 
 module.exports = ProcessNodeDefinitions;
-

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
   },
   "dependencies": {
     "htmlparser2": "^3.8.3",
-    "lodash": "^3.9.3"
+    "lodash": "^4.3.0"
   },
   "devDependencies": {
     "blanket": "1.1.7",


### PR DESCRIPTION
No thing changed. 

`_.isNull(styleString) || _.isUndefined(styleString)` stills work but `_.isNil(styleString)` is a sugar syntax for that
