### PR TITLE
Use modularized lodash

### DIFF
--- a/lib/parser.js
+++ b/lib/parser.js
@@ -1,6 +1,7 @@
 'use strict';
 
-var _ = require('lodash');
+var forEach = require('lodash.foreach');
+var compact = require('lodash.compact');
 var htmlParser = require('htmlparser2');
 var ProcessingInstructions = require('./processing-instructions');
 var IsValidNodeDefinitions = require('./is-valid-node-definitions');
@@ -16,10 +17,10 @@ var Html2React = function(React) {
     var traverseDom = function(node, isValidNode, processingInstructions) {
         if (isValidNode(node)) {
             var children = [];
-            _.each(node.children, function(child) {
+            forEach(node.children, function(child) {
                 children.push(traverseDom(child, isValidNode, processingInstructions));
             });
-            _.compact(children); // Remove invalid nodes
+            compact(children); // Remove invalid nodes
             for (var index = 0; index < processingInstructions.length; index++) {
                 var processingInstruction = processingInstructions[index];
                 if (processingInstruction.shouldProcessNode(node)) {
@@ -55,4 +56,3 @@ var Html2React = function(React) {
 };
 
 module.exports = Html2React;
-

--- a/lib/parser.js
+++ b/lib/parser.js
@@ -1,7 +1,7 @@
 'use strict';
 
-var forEach = require('lodash.foreach');
 var compact = require('lodash.compact');
+var forEach = require('lodash.foreach');
 var htmlParser = require('htmlparser2');
 var ProcessingInstructions = require('./processing-instructions');
 var IsValidNodeDefinitions = require('./is-valid-node-definitions');

--- a/lib/parser.js
+++ b/lib/parser.js
@@ -1,6 +1,8 @@
 'use strict';
 
-var _ = require('lodash');
+var compact = require('lodash.compact');
+var find = require('lodash.find');
+var map = require('lodash.map');
 var htmlParser = require('htmlparser2');
 var ProcessingInstructions = require('./processing-instructions');
 var IsValidNodeDefinitions = require('./is-valid-node-definitions');
@@ -15,12 +17,12 @@ var Html2React = function(React, options) {
 
     var traverseDom = function(node, isValidNode, processingInstructions, index) {
         if (isValidNode(node)) {
-            var processingInstruction = _.find(processingInstructions || [],
+            var processingInstruction = find(processingInstructions || [],
                     function (processingInstruction) {
                 return processingInstruction.shouldProcessNode(node);
             });
             if (processingInstruction != null) {
-                var children = _.compact(_.map(node.children, function (child, i) {
+                var children = compact(map(node.children, function (child, i) {
                     return traverseDom(child, isValidNode, processingInstructions, i);
                 }));
                 return processingInstruction.processNode(node, children, index);

--- a/lib/process-node-definitions.js
+++ b/lib/process-node-definitions.js
@@ -1,16 +1,17 @@
 'use strict';
 
-var _ = require('lodash');
+var forEach = require('lodash.foreach');
+var camelCase = require('lodash.camelcase');
 
 function createStyleJsonFromString(styleString) {
-    if (_.isNull(styleString) || _.isUndefined(styleString) || styleString === '') {
+    if (!styleString) {
         return {};
     }
     var styles = styleString.split(';');
     var singleStyle, key, value, jsonStyles = {};
     for (var i = 0; i < styles.length; i++) {
         singleStyle = styles[i].split(':');
-        key = _.camelCase(singleStyle[0]);
+        key = camelCase(singleStyle[0]);
         value = singleStyle[1];
         if (key.length > 0 && value.length > 0) {
             jsonStyles[key] = value;
@@ -36,7 +37,7 @@ var ProcessNodeDefinitions = function(React) {
         };
         // Process attributes
         if (node.attribs) {
-            _.each(node.attribs, function(value, key) {
+            forEach(node.attribs, function(value, key) {
                 switch (key || '') {
                     case 'style':
                         elementProps.style = createStyleJsonFromString(node.attribs.style);
@@ -60,4 +61,3 @@ var ProcessNodeDefinitions = function(React) {
 };
 
 module.exports = ProcessNodeDefinitions;
-

--- a/lib/process-node-definitions.js
+++ b/lib/process-node-definitions.js
@@ -1,7 +1,8 @@
 'use strict';
 
-var forEach = require('lodash.foreach');
 var camelCase = require('lodash.camelcase');
+var contains = require('lodash.contains');
+var forEach = require('lodash.foreach');
 var ent = require('ent');
 
 // https://github.com/facebook/react/blob/0.14-stable/src/renderers/dom/shared/ReactDOMComponent.js#L457
@@ -59,7 +60,7 @@ var ProcessNodeDefinitions = function(React) {
             });
         }
 
-        if (_.contains(voidElementTags, node.name)) {
+        if (contains(voidElementTags, node.name)) {
             return React.createElement(node.name, elementProps)
         } else {
         return React.createElement(node.name, elementProps, node.data, children);

--- a/lib/process-node-definitions.js
+++ b/lib/process-node-definitions.js
@@ -1,8 +1,8 @@
 'use strict';
 
 var camelCase = require('lodash.camelcase');
-var contains = require('lodash.contains');
 var forEach = require('lodash.foreach');
+var includes = require('lodash.includes');
 var ent = require('ent');
 
 // https://github.com/facebook/react/blob/0.14-stable/src/renderers/dom/shared/ReactDOMComponent.js#L457
@@ -60,7 +60,7 @@ var ProcessNodeDefinitions = function(React) {
             });
         }
 
-        if (contains(voidElementTags, node.name)) {
+        if (includes(voidElementTags, node.name)) {
             return React.createElement(node.name, elementProps)
         } else {
         return React.createElement(node.name, elementProps, node.data, children);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "html-to-react",
-  "version": "0.1.3",
+  "version": "0.1.2",
   "description": "A lightweight library that converts raw HTML to a React DOM structure.",
   "main": "index.js",
   "scripts": {
@@ -45,7 +45,7 @@
     "coveralls": "^2.11.2",
     "mocha": "^2.2.5",
     "mocha-lcov-reporter": "0.0.2",
-    "react": "^15.0.1",
-    "react-dom": "^15.0.1"
+    "react": "^0.14.7",
+    "react-dom": "^0.14.7"
   }
 }

--- a/package.json
+++ b/package.json
@@ -36,9 +36,10 @@
   "dependencies": {
     "ent": "^2.2.0",
     "htmlparser2": "^3.8.3",
-    "lodash.foreach": "^4.1.0",
+    "lodash.camelcase": "^4.1.0",
     "lodash.compact": "^3.0.1",
-    "lodash.camelcase": "^4.1.0"
+    "lodash.contains": "^2.4.3",
+    "lodash.foreach": "^4.1.0"
   },
   "devDependencies": {
     "coveralls": "2.11.9",

--- a/package.json
+++ b/package.json
@@ -38,12 +38,15 @@
     "htmlparser2": "^3.8.3",
     "lodash.camelcase": "^4.1.0",
     "lodash.compact": "^3.0.1",
-    "lodash.foreach": "^4.1.0",
-    "lodash.includes": "^4.1.2"
+    "lodash.find": "^4.3.0",
+    "lodash.foreach": "^4.2.0",
+    "lodash.includes": "^4.1.2",
+    "lodash.map": "^4.3.0"
   },
   "devDependencies": {
     "coveralls": "2.11.9",
     "istanbul": "0.4.3",
+    "lodash": "^4.11.1",
     "mocha": "2.4.5",
     "mocha-lcov-reporter": "1.2.0",
     "react": "^0.14.7",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "html-to-react",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "A lightweight library that converts raw HTML to a React DOM structure.",
   "main": "index.js",
   "scripts": {
@@ -45,7 +45,7 @@
     "coveralls": "^2.11.2",
     "mocha": "^2.2.5",
     "mocha-lcov-reporter": "0.0.2",
-    "react": "^0.14.7",
-    "react-dom": "^0.14.7"
+    "react": "^15.0.1",
+    "react-dom": "^15.0.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -36,7 +36,9 @@
   },
   "dependencies": {
     "htmlparser2": "^3.8.3",
-    "lodash": "^3.9.3"
+    "lodash.foreach": "^4.1.0",
+    "lodash.compact": "^3.0.1",
+    "lodash.camelcase": "^4.1.0"
   },
   "devDependencies": {
     "blanket": "1.1.7",

--- a/package.json
+++ b/package.json
@@ -38,8 +38,8 @@
     "htmlparser2": "^3.8.3",
     "lodash.camelcase": "^4.1.0",
     "lodash.compact": "^3.0.1",
-    "lodash.contains": "^2.4.3",
-    "lodash.foreach": "^4.1.0"
+    "lodash.foreach": "^4.1.0",
+    "lodash.includes": "^4.1.2"
   },
   "devDependencies": {
     "coveralls": "2.11.9",


### PR DESCRIPTION
Simplified lodash dependencies so as to use only the functions needed. The reason for this is that when using this package on client, including the whole lodash makes the bundle unnecessarily big. Also simplified the condition in `lib/process-node-definitions.js`.

This PR should also resolve #23.
