### PR TITLE
Change key assignment to be only where needed, based on node order

### DIFF
--- a/lib/parser.js
+++ b/lib/parser.js
@@ -16,7 +16,10 @@ var Html2React = function(React) {
     var traverseDom = function(node, isValidNode, processingInstructions) {
         if (isValidNode(node)) {
             var children = [];
-            _.each(node.children, function(child) {
+            _.each(node.children, function(child, index) {
+                if (node.children.length > 1 && child.type === 'tag') {
+                    child.attribs.key = child.attribs.key || index;
+                }
                 children.push(traverseDom(child, isValidNode, processingInstructions));
             });
             _.compact(children); // Remove invalid nodes

--- a/lib/process-node-definitions.js
+++ b/lib/process-node-definitions.js
@@ -20,8 +20,6 @@ function createStyleJsonFromString(styleString) {
 }
 
 var ProcessNodeDefinitions = function(React) {
-    var index = 0;
-
     function processDefaultNode(node, children) {
         if (node.type === 'text') {
             return node.data;
@@ -31,9 +29,7 @@ var ProcessNodeDefinitions = function(React) {
             return false;
         }
 
-        var elementProps = {
-            key: ++index
-        };
+        var elementProps = {};
         // Process attributes
         if (node.attribs) {
             _.each(node.attribs, function(value, key) {


### PR DESCRIPTION
The current method of allocating a new unique key on each render means all react components re-mount on each render. This is bad for components which would otherwise nicely animate the state change. The proposed method here assigns a persistent key when needed - based on child node order. If a key already exists on the node then it is used.
