### PR TITLE
Strip out white space text nodes

### DIFF
--- a/lib/processing-instructions.js
+++ b/lib/processing-instructions.js
@@ -8,7 +8,7 @@ var ProcessingInstructions = function(React) {
 
     return {
         defaultProcessingInstructions: [{
-            shouldProcessNode: ShouldProcessNodeDefinitions.shouldProcessEveryNode,
+            shouldProcessNode: ShouldProcessNodeDefinitions.shouldProcessEveryNodeExceptWhiteSpace,
             processNode: processNodeDefinitions.processDefaultNode
         }]
     };

--- a/lib/should-process-node-definitions.js
+++ b/lib/should-process-node-definitions.js
@@ -4,6 +4,11 @@ function shouldProcessEveryNode(node) {
     return true;
 }
 
+function shouldProcessEveryNodeExceptWhiteSpace(node) {
+    return node.type !== 'text' || node.data.trim();
+}
+
 module.exports = {
-    shouldProcessEveryNode: shouldProcessEveryNode
+    shouldProcessEveryNode: shouldProcessEveryNode,
+    shouldProcessEveryNodeExceptWhiteSpace: shouldProcessEveryNodeExceptWhiteSpace
 };

--- a/test/html-to-react-tests.js
+++ b/test/html-to-react-tests.js
@@ -101,6 +101,47 @@ describe('Html2React', function() {
 
             assert.equal(reactHtml, htmlExpected);
         });
+
+        it('should not insert spans into tables even if there is white space', function() {
+            var htmlInput = '<table> <tbody> <tr>\n<td>x</td> <td>3</td> </tr> </tbody> </table>';
+            var htmlExpected = '<table><tbody><tr><td>x</td><td>3</td></tr></tbody></table>';
+
+            var reactComponent = parser.parse(htmlInput);
+            var reactHtml = ReactDOMServer.renderToStaticMarkup(reactComponent);
+
+            assert.equal(reactHtml, htmlExpected);
+        });
+
+        it('should preserve leading white space in a div', function() {
+            var htmlInput = '<div> hi</div>';
+
+            var reactComponent = parser.parse(htmlInput);
+            var reactHtml = ReactDOMServer.renderToStaticMarkup(reactComponent);
+
+            assert.equal(reactHtml, htmlInput);
+        });
+
+        // Should it strip out contents of a div containing only white space?
+        it('should strip out contents of a div containing only white space', function() {
+            var htmlInput = '<div>  </div>';
+            var htmlExpected = '<div></div>';
+
+            var reactComponent = parser.parse(htmlInput);
+            var reactHtml = ReactDOMServer.renderToStaticMarkup(reactComponent);
+
+            assert.equal(reactHtml, htmlExpected);
+        });
+
+        // Should it strip out white space that is a sibling to an element?
+        it('should strip out white space that is a sibling to an element', function() {
+            var htmlInput = '<div> <span>hi</span>bye</div>';
+            var htmlExpected = '<div><span>hi</span>bye</div>';
+
+            var reactComponent = parser.parse(htmlInput);
+            var reactHtml = ReactDOMServer.renderToStaticMarkup(reactComponent);
+
+            assert.equal(reactHtml, htmlExpected);
+        });
     });
 
     describe('parse invalid HTML', function() {


### PR DESCRIPTION
Fixes #30 ("Should not insert spans into tables even if there is white space") by stripping out _all_ white-space text nodes.

This changes non-table nodes too, e.g.:
`<div>  </div>` into `<div></div>` 
`<div>  <span>hi</span>bye</div>` into `<div><span>hi</span>bye</div>`.

I'm not sure if that is desirable. If it's not, is there a better solution?
