### PR TITLE
Don't add null or nested children to elements

### DIFF
--- a/lib/process-node-definitions.js
+++ b/lib/process-node-definitions.js
@@ -61,13 +61,15 @@ var ProcessNodeDefinitions = function(React) {
         if (includes(voidElementTags, node.name)) {
             return React.createElement(node.name, elementProps)
         } else {
-        return React.createElement(node.name, elementProps, node.data, children);
-    }
-
+            var allChildren = node.data != null ? [node.data,].concat(children) : children;
+            return React.createElement.apply(
+                this, [node.name, elementProps,].concat(allChildren)
+            );
+        }
     }
 
     return {
-        processDefaultNode: processDefaultNode
+        processDefaultNode: processDefaultNode,
     };
 };
 

--- a/test/html-to-react-tests.js
+++ b/test/html-to-react-tests.js
@@ -142,6 +142,14 @@ describe('Html2React', function() {
             assert.equal(reactHtml, htmlInput);
         });
 
+        it('should not generate children for childless elements', function () {
+            var htmlInput = '<div></div>';
+
+            var reactComponent = parser.parse(htmlInput);
+
+            assert.strictEqual((reactComponent.props.children || []).length, 0);
+        });
+
         it('should fill in the key name with boolean attribute', function() {
             var htmlInput = '<input type="checkbox" disabled required/>';
             var htmlExpected = '<input type="checkbox" disabled="" required=""/>'


### PR DESCRIPTION
I noticed that elements end up having `null` children and nested ones as well, which caused some issues in my fork of html-to-react. I eventually figured out that the reason is that nodes' `data` property is always passed as the first child and that any children are passed in a nested manner to `react.createElement`.

Doesn't look as if React is too bothered by this, but it makes for confusing debugging at the very least (as the element's children are typically a `null` and then a list). Therefore I made the modification to not pass a null data property as a child and to not pass children in a nested way, but as variable arguments to `react.createElement`, which seems to be its proper signature.
