### PR TITLE
Map lowercase HTML attrs to camelCase React ones

### DIFF
--- a/lib/camel-case-attribute-names.js
+++ b/lib/camel-case-attribute-names.js
@@ -1,3 +1,6 @@
+// These are all sourced from https://facebook.github.io/react/docs/tags-and-attributes.html - all attributes regardless
+// of whether they have a different case to their HTML equivalents are listed to reduce the chance of human error
+// and make it easier to just copy-paste the new list if it changes.
 var HTML_ATTRIBUTES = [
     'accept', 'acceptCharset', 'accessKey', 'action', 'allowFullScreen', 'allowTransparency', 'alt',
     'async', 'autoComplete', 'autoFocus', 'autoPlay', 'capture', 'cellPadding', 'cellSpacing', 'challenge',
@@ -55,7 +58,12 @@ var camelCaseMap = HTML_ATTRIBUTES
     .concat(NON_STANDARD_ATTRIBUTES)
     .concat(SVG_ATTRIBUTES)
     .reduce(function(soFar, attr) {
-        soFar[attr.toLowerCase()] = attr;
+        var lower = attr.toLowerCase();
+
+        if (lower !== attr) {
+            soFar[lower] = attr;
+        }
+
         return soFar;
     }, {});
 

--- a/lib/camel-case-attribute-names.js
+++ b/lib/camel-case-attribute-names.js
@@ -1,0 +1,62 @@
+var HTML_ATTRIBUTES = [
+    'accept', 'acceptCharset', 'accessKey', 'action', 'allowFullScreen', 'allowTransparency', 'alt',
+    'async', 'autoComplete', 'autoFocus', 'autoPlay', 'capture', 'cellPadding', 'cellSpacing', 'challenge',
+    'charSet', 'checked', 'cite', 'classID', 'className', 'colSpan', 'cols', 'content', 'contentEditable',
+    'contextMenu', 'controls', 'coords', 'crossOrigin', 'data', 'dateTime', 'default', 'defer', 'dir',
+    'disabled', 'download', 'draggable', 'encType', 'form', 'formAction', 'formEncType', 'formMethod',
+    'formNoValidate', 'formTarget', 'frameBorder', 'headers', 'height', 'hidden', 'high', 'href', 'hrefLang',
+    'htmlFor', 'httpEquiv', 'icon', 'id', 'inputMode', 'integrity', 'is', 'keyParams', 'keyType', 'kind', 'label',
+    'lang', 'list', 'loop', 'low', 'manifest', 'marginHeight', 'marginWidth', 'max', 'maxLength', 'media',
+    'mediaGroup', 'method', 'min', 'minLength', 'multiple', 'muted', 'name', 'noValidate', 'nonce', 'open',
+    'optimum', 'pattern', 'placeholder', 'poster', 'preload', 'profile', 'radioGroup', 'readOnly', 'rel',
+    'required', 'reversed', 'role', 'rowSpan', 'rows', 'sandbox', 'scope', 'scoped', 'scrolling', 'seamless',
+    'selected', 'shape', 'size', 'sizes', 'span', 'spellCheck', 'src', 'srcDoc', 'srcLang', 'srcSet', 'start', 'step',
+    'style', 'summary', 'tabIndex', 'target', 'title', 'type', 'useMap', 'value', 'width', 'wmode', 'wrap'
+];
+
+var NON_STANDARD_ATTRIBUTES = [
+    'autoCapitalize', 'autoCorrect', 'color', 'itemProp', 'itemScope', 'itemType', 'itemRef', 'itemID', 'security',
+    'unselectable', 'results', 'autoSave'
+];
+
+var SVG_ATTRIBUTES = [
+    'accentHeight', 'accumulate', 'additive', 'alignmentBaseline', 'allowReorder', 'alphabetic', 'amplitude',
+    'arabicForm', 'ascent', 'attributeName', 'attributeType', 'autoReverse', 'azimuth', 'baseFrequency', 'baseProfile',
+    'baselineShift', 'bbox', 'begin', 'bias', 'by', 'calcMode', 'capHeight', 'clip', 'clipPath', 'clipPathUnits',
+    'clipRule', 'colorInterpolation', 'colorInterpolationFilters', 'colorProfile', 'colorRendering', 'contentScriptType',
+    'contentStyleType', 'cursor', 'cx', 'cy', 'd', 'decelerate', 'descent', 'diffuseConstant', 'direction', 'display',
+    'divisor',    'dominantBaseline', 'dur', 'dx', 'dy', 'edgeMode', 'elevation', 'enableBackground', 'end', 'exponent',
+    'externalResourcesRequired', 'fill', 'fillOpacity', 'fillRule', 'filter', 'filterRes', 'filterUnits', 'floodColor',
+    'floodOpacity', 'focusable', 'fontFamily', 'fontSize', 'fontSizeAdjust', 'fontStretch', 'fontStyle', 'fontVariant',
+    'fontWeight', 'format', 'from', 'fx', 'fy', 'g1', 'g2', 'glyphName', 'glyphOrientationHorizontal',
+    'glyphOrientationVertical', 'glyphRef', 'gradientTransform', 'gradientUnits', 'hanging', 'horizAdvX', 'horizOriginX',
+    'ideographic', 'imageRendering', 'in', 'in2', 'intercept', 'k', 'k1', 'k2', 'k3', 'k4', 'kernelMatrix',
+    'kernelUnitLength', 'kerning', 'keyPoints', 'keySplines', 'keyTimes', 'lengthAdjust', 'letterSpacing', 'lightingColor',
+    'limitingConeAngle', 'local', 'markerEnd', 'markerHeight', 'markerMid', 'markerStart', 'markerUnits', 'markerWidth',
+    'mask', 'maskContentUnits', 'maskUnits', 'mathematical', 'mode', 'numOctaves', 'offset', 'opacity', 'operator', 'order',
+    'orient', 'orientation', 'origin', 'overflow', 'overlinePosition', 'overlineThickness', 'paintOrder', 'panose1',
+    'pathLength', 'patternContentUnits', 'patternTransform', 'patternUnits', 'pointerEvents', 'points', 'pointsAtX',
+    'pointsAtY', 'pointsAtZ', 'preserveAlpha', 'preserveAspectRatio', 'primitiveUnits', 'r', 'radius', 'refX', 'refY',
+    'renderingIntent', 'repeatCount', 'repeatDur', 'requiredExtensions', 'requiredFeatures', 'restart', 'result', 'rotate',
+    'rx', 'ry', 'scale', 'seed', 'shapeRendering', 'slope', 'spacing', 'specularConstant', 'specularExponent', 'speed',
+    'spreadMethod', 'startOffset', 'stdDeviation', 'stemh', 'stemv', 'stitchTiles', 'stopColor', 'stopOpacity',
+    'strikethroughPosition', 'strikethroughThickness', 'string', 'stroke', 'strokeDasharray', 'strokeDashoffset',
+    'strokeLinecap', 'strokeLinejoin', 'strokeMiterlimit', 'strokeOpacity', 'strokeWidth', 'surfaceScale',
+    'systemLanguage', 'tableValues', 'targetX', 'targetY', 'textAnchor', 'textDecoration', 'textLength', 'textRendering',
+    'to', 'transform', 'u1', 'u2', 'underlinePosition', 'underlineThickness', 'unicode', 'unicodeBidi', 'unicodeRange',
+    'unitsPerEm', 'vAlphabetic', 'vHanging', 'vIdeographic', 'vMathematical', 'values', 'vectorEffect', 'version',
+    'vertAdvY', 'vertOriginX', 'vertOriginY', 'viewBox', 'viewTarget', 'visibility', 'widths', 'wordSpacing',
+    'writingMode', 'x', 'x1', 'x2', 'xChannelSelector', 'xHeight', 'xlinkActuate', 'xlinkArcrole', 'xlinkHref',
+    'xlinkRole', 'xlinkShow', 'xlinkTitle', 'xlinkType', 'xmlBase', 'xmlLang', 'xmlSpace', 'y', 'y1', 'y2',
+    'yChannelSelector', 'z', 'zoomAndPan'
+];
+
+var camelCaseMap = HTML_ATTRIBUTES
+    .concat(NON_STANDARD_ATTRIBUTES)
+    .concat(SVG_ATTRIBUTES)
+    .reduce(function(soFar, attr) {
+        soFar[attr.toLowerCase()] = attr;
+        return soFar;
+    }, {});
+
+module.exports = camelCaseMap;

--- a/lib/process-node-definitions.js
+++ b/lib/process-node-definitions.js
@@ -4,6 +4,7 @@ var camelCase = require('lodash.camelcase');
 var forEach = require('lodash.foreach');
 var includes = require('lodash.includes');
 var ent = require('ent');
+var camelCaseAttrMap = require('./camel-case-attribute-names');
 
 // https://github.com/facebook/react/blob/0.14-stable/src/renderers/dom/shared/ReactDOMComponent.js#L457
 var voidElementTags = [
@@ -44,16 +45,14 @@ var ProcessNodeDefinitions = function(React) {
         // Process attributes
         if (node.attribs) {
             forEach(node.attribs, function(value, key) {
-                switch (key || '') {
-                    case 'style':
-                        elementProps.style = createStyleJsonFromString(node.attribs.style);
-                        break;
-                    case 'class':
-                        elementProps.className = value;
-                        break;
-                    default:
-                        elementProps[key] = value;
-                        break;
+                if (key === 'style') {
+                    elementProps.style = createStyleJsonFromString(node.attribs.style);
+                } else if (key === 'class') {
+                    elementProps.className = value
+                } else if (camelCaseAttrMap[key]) {
+                    elementProps[camelCaseAttrMap[key]] = value;
+                } else {
+                    elementProps[key] = value;
                 }
             });
         }
@@ -61,8 +60,8 @@ var ProcessNodeDefinitions = function(React) {
         if (includes(voidElementTags, node.name)) {
             return React.createElement(node.name, elementProps)
         } else {
-        return React.createElement(node.name, elementProps, node.data, children);
-    }
+            return React.createElement(node.name, elementProps, node.data, children);
+        }
 
     }
 

--- a/test/html-to-react-tests.js
+++ b/test/html-to-react-tests.js
@@ -76,6 +76,15 @@ describe('Html2React', function() {
             assert.equal(reactHtml, htmlInput);
         });
 
+        it('should return a valid HTML string with a react camelCase attribute', function() {
+            var htmlInput = '<div contenteditable="true"></div>';
+
+            var reactComponent = parser.parse(htmlInput);
+            var reactHtml = ReactDOMServer.renderToStaticMarkup(reactComponent);
+
+            assert.equal(reactHtml, htmlInput);
+        });
+
         // FIXME: See lib/process-node-definitions.js -> processDefaultNode()
         it.skip('should return a valid HTML string with comments', function() {
             var htmlInput = '<div><!-- This is a comment --></div>';


### PR DESCRIPTION
First up thanks for making this!

Right now when converting elements, all attributes except `class` and `style` have their name and value copied over from the HTML element to the React one - however, this means that valid lowercase HTML attributes like `colspan` aren't converted to their React equivalent (`colSpan`) and as a result don't work.

What this does is take the attributes specified in https://facebook.github.io/react/docs/tags-and-attributes.html, finds all the ones that aren't lowercase and puts them into a map from the HTML version to the React one. When copying attributes the new code checks if the attribute name is in this map, and if it does it substitutes the react version of the name for the HTML one.
