### PR TITLE
Fill in key name with boolean attribute

### DIFF
--- a/lib/process-node-definitions.js
+++ b/lib/process-node-definitions.js
@@ -52,7 +52,7 @@ var ProcessNodeDefinitions = function(React) {
                         elementProps.className = value;
                         break;
                     default:
-                        elementProps[key] = value;
+                        elementProps[key] = value || key;
                         break;
                 }
             });

--- a/test/html-to-react-tests.js
+++ b/test/html-to-react-tests.js
@@ -141,6 +141,16 @@ describe('Html2React', function() {
 
             assert.equal(reactHtml, htmlInput);
         });
+
+        it('should fill in the key name with boolean attribute', function() {
+            var htmlInput = '<input type="checkbox" disabled required/>';
+            var htmlExpected = '<input type="checkbox" disabled="" required=""/>'
+
+            var reactComponent = parser.parse(htmlInput);
+            var reactHtml = ReactDOMServer.renderToStaticMarkup(reactComponent);
+
+            assert.equal(reactHtml, htmlExpected);
+        });
     });
 
     describe('parse invalid HTML', function() {


### PR DESCRIPTION
Currently if we need to parse the boolean attributes, we have to specify values of them with the attribute name.

``` html
<input required="required" />
// compiles to...
<input required />
```

In other words, this won't work...

``` html
<input required />
// compiles to...
<input />
```

I added a very simple logic to auto fill in the key name of the attribute to the value if the value is empty.

``` html
<input required />
// compiles to...
<input required="" />
```
