### PR TITLE
Replace element children

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,83 @@ var reactHtml = React.renderToStaticMarkup(reactComponent);
 assert.equal(reactHtml, htmlExpected);
 ```
 
+### Replace the children of an element
+
+There may be a situation where you want to replace the children of an element with a React component. This is
+beneficial if you want to:
+- a) preserve the containing element
+- b) not rely on any child node to insert your React component
+
+#### Example
+
+Below is a simple template that could get loaded via ajax into your application
+
+##### Before
+```
+<div class="row">
+    <div class="col-sm-6">
+        <div data-container="wysiwyg">
+            <h1>Sample Heading</h1>
+            <p>Sample Text</p>
+        </div>
+    </div>
+</div>
+```
+
+##### After
+
+You may want to extract the inner html from the `data-container` attribute, store it and then pass it as a
+prop to your injected `RichTextEditor`.
+
+```
+<div class="row">
+    <div class="col-sm-6">
+        <div data-container="wysiwyg">
+            <RichTextEditor html={"<h1>Sample heading</h1><p>Sample Text</p>"} />
+        </div>
+    </div>
+</div>
+```
+
+#### Setup
+
+In your instructions object, you must specify `replaceChildren: true`.
+
+```javascript
+var React = require('react');
+var HtmlToReact = new require('html-to-react');
+
+var htmlInput = '<div><div data-test="foo"><p>Text</p><p>Text</p></div></div>';
+var htmlExpected = '<div><div data-test="foo"><h1>Heading</h1></div></div>';
+
+var isValidNode = function() {
+    return true;
+};
+
+// Order matters. Instructions are processed in the order they're defined
+var processingInstructions = [{
+    // This is REQUIRED, it tells the parser that we want to insert our React component as a child
+    replaceChildren: true,
+    shouldProcessNode: function(node) {
+        return node.attribs && node.attribs['data-test'] === 'foo';
+    },
+    processNode: function(node, children, index) {
+        return React.createElement('h1', { key: index }, 'Heading');
+    }
+},
+{
+    // Anything else
+    shouldProcessNode: function(node) {
+        return true;
+    },
+    processNode: processNodeDefinitions.processDefaultNode
+}];
+
+var reactComponent = parser.parseWithInstructions(htmlInput, isValidNode, processingInstructions);
+var reactHtml = ReactDOMServer.renderToStaticMarkup(reactComponent);
+assert.equal(reactHtml, htmlExpected);
+```
+
 ## Tests & Coverage
 
 `$ npm run test-locally`

--- a/lib/parser.js
+++ b/lib/parser.js
@@ -6,6 +6,7 @@ var map = require('lodash.map');
 var htmlParser = require('htmlparser2');
 var ProcessingInstructions = require('./processing-instructions');
 var IsValidNodeDefinitions = require('./is-valid-node-definitions');
+var utils = require('./utils');
 
 var Html2React = function(React, options) {
     var parseHtmlToTree = function(html) {
@@ -25,6 +26,15 @@ var Html2React = function(React, options) {
                 var children = compact(map(node.children, function (child, i) {
                     return traverseDom(child, isValidNode, processingInstructions, i);
                 }));
+
+                if (processingInstruction.replaceChildren) {
+                    var elementProps = utils.createElementProps(node, index);
+
+                    return React.createElement(node.name, elementProps, node.data, [
+                        processingInstruction.processNode(node, children, index)
+                    ]);
+                }
+
                 return processingInstruction.processNode(node, children, index);
             } else {
                 return false;

--- a/lib/process-node-definitions.js
+++ b/lib/process-node-definitions.js
@@ -1,32 +1,14 @@
 'use strict';
 
-var camelCase = require('lodash.camelcase');
-var forEach = require('lodash.foreach');
 var includes = require('lodash.includes');
 var ent = require('ent');
+var utils = require('./utils');
 
 // https://github.com/facebook/react/blob/0.14-stable/src/renderers/dom/shared/ReactDOMComponent.js#L457
 var voidElementTags = [
     'area', 'base', 'br', 'col', 'embed', 'hr', 'img', 'input',
     'keygen', 'link', 'meta', 'param', 'source', 'track', 'wbr', 'textarea',
 ];
-
-function createStyleJsonFromString(styleString) {
-    if (!styleString) {
-        return {};
-    }
-    var styles = styleString.split(';');
-    var singleStyle, key, value, jsonStyles = {};
-    for (var i = 0; i < styles.length; i++) {
-        singleStyle = styles[i].split(':');
-        key = camelCase(singleStyle[0]);
-        value = singleStyle[1];
-        if (key.length > 0 && value.length > 0) {
-            jsonStyles[key] = value;
-        }
-    }
-    return jsonStyles;
-}
 
 var ProcessNodeDefinitions = function(React) {
     function processDefaultNode(node, children, index) {
@@ -38,25 +20,7 @@ var ProcessNodeDefinitions = function(React) {
             return false;
         }
 
-        var elementProps = {
-            key: index,
-        };
-        // Process attributes
-        if (node.attribs) {
-            forEach(node.attribs, function(value, key) {
-                switch (key || '') {
-                    case 'style':
-                        elementProps.style = createStyleJsonFromString(node.attribs.style);
-                        break;
-                    case 'class':
-                        elementProps.className = value;
-                        break;
-                    default:
-                        elementProps[key] = value;
-                        break;
-                }
-            });
-        }
+        var elementProps = utils.createElementProps(node, index);
 
         if (includes(voidElementTags, node.name)) {
             return React.createElement(node.name, elementProps)

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1,0 +1,51 @@
+'use strict';
+
+var camelCase = require('lodash.camelcase');
+var forEach = require('lodash.foreach');
+var includes = require('lodash.includes');
+
+function createStyleJsonFromString(styleString) {
+    if (!styleString) {
+        return {};
+    }
+    var styles = styleString.split(';');
+    var singleStyle, key, value, jsonStyles = {};
+    for (var i = 0; i < styles.length; i++) {
+        singleStyle = styles[i].split(':');
+        key = camelCase(singleStyle[0]);
+        value = singleStyle[1];
+        if (key.length > 0 && value.length > 0) {
+            jsonStyles[key] = value;
+        }
+    }
+    return jsonStyles;
+}
+
+function createElementProps(node, index) {
+    var elementProps = {
+        key: index
+    };
+
+    // Process attributes
+    if (node.attribs) {
+        forEach(node.attribs, function(value, key) {
+            switch (key || '') {
+                case 'style':
+                    elementProps.style = createStyleJsonFromString(node.attribs.style);
+                    break;
+                case 'class':
+                    elementProps.className = value;
+                    break;
+                default:
+                    elementProps[key] = value;
+                    break;
+            }
+        });
+    }
+
+    return elementProps;
+}
+
+module.exports = {
+    createElementProps: createElementProps
+};

--- a/test/html-to-react-tests.js
+++ b/test/html-to-react-tests.js
@@ -212,6 +212,36 @@ describe('Html2React', function() {
                 assert.equal(reactHtml, htmlExpected);
             });
 
+            it('should replace the children of an element', function() {
+                var htmlInput = '<div><div data-test="foo"><p>Text</p><p>Text</p></div></div>';
+                var htmlExpected = '<div><div data-test="foo"><h1>Heading</h1></div></div>';
+
+                var isValidNode = function() {
+                    return true;
+                };
+
+                var processingInstructions = [{
+                    replaceChildren: true,
+                    shouldProcessNode: function(node) {
+                        return node.attribs && node.attribs['data-test'] === 'foo';
+                    },
+                    processNode: function(node, children, index) {
+                        return React.createElement('h1', { key: index }, 'Heading');
+                    }
+                },
+                {
+                    // Anything else
+                    shouldProcessNode: function(node) {
+                        return true;
+                    },
+                    processNode: processNodeDefinitions.processDefaultNode
+                }];
+
+                var reactComponent = parser.parseWithInstructions(htmlInput, isValidNode, processingInstructions);
+                var reactHtml = ReactDOMServer.renderToStaticMarkup(reactComponent);
+                assert.equal(reactHtml, htmlExpected);
+            });
+
             it('should return capitalized content for all <h1> elements', function() {
                 var htmlInput = '<div><h1>Title</h1><p>Paragraph</p><h1>Another title</h1></div>';
                 var htmlExpected = '<div><h1>TITLE</h1><p>Paragraph</p><h1>ANOTHER TITLE</h1></div>';


### PR DESCRIPTION
Hi, I would like to propose the ability to replace all children of an element with a given React component.
### Problem

Given this HTML template

```
<div class="row">
    <div class="col-sm-6">
        <div data-container="wysiwyg">
            <h1>Sample Heading</h1>
            <p>Sample Text</p>
        </div>
    </div>
</div>
```

I would like to
- a) Preserve the `data-container` element.
- b) Replace the inner html of `data-container` with my custom React component.

The current solution is to check the child node's parent. This breaks down as soon as you start having multiple children
### Solution

Given a Processing Instruction, you can now set a new property called `{boolean} replaceChildren`.

This property will tell the parser to add the returned component from `processNode` as a child of the created React element. The template shown above would become:

```
<div class="row">
    <div class="col-sm-6">
        <div data-container="wysiwyg">
            <RichTextEditor html={"<h1>Sample heading</h1><p>Sample Text</p>"} />
        </div>
    </div>
</div>
```

We would love to hear thoughts on this.
