### PR TITLE
Add "defaultChecked" value to NON_STANDARD_ATTRIBUTES

### DIFF
--- a/lib/camel-case-attribute-names.js
+++ b/lib/camel-case-attribute-names.js
@@ -24,7 +24,7 @@ var HTML_ATTRIBUTES = [
 
 var NON_STANDARD_ATTRIBUTES = [
     'autoCapitalize', 'autoCorrect', 'color', 'itemProp', 'itemScope', 'itemType', 'itemRef',
-    'itemID', 'security', 'unselectable', 'results', 'autoSave',
+    'itemID', 'security', 'unselectable', 'results', 'autoSave', 'defaultChecked',
 ];
 
 var SVG_ATTRIBUTES = [


### PR DESCRIPTION
Using in a input tag the "checked" attribute, the lib throws an error.
I fixed it adding the value "defaultChecked" in the NON_STANDARD_ATTRIBUTES array in "camel-case-attribute-names.js" file.